### PR TITLE
fix for default settings

### DIFF
--- a/jstmc/events.py
+++ b/jstmc/events.py
@@ -100,6 +100,7 @@ class RF(Event):
                         freq_offset_hz: float = 0.0, phase_offset_rad: float = 0.0,
                         time_bw_prod: float = 2):
         rf_instance = cls()
+        rf_instance.system = system
         rf_simple_ns = pp.make_sinc_pulse(
             use=pulse_type,
             flip_angle=flip_angle_rad,

--- a/jstmc/sequence.py
+++ b/jstmc/sequence.py
@@ -660,7 +660,7 @@ class JsTmcSequence:
             "gradMode": "Normal",
             "excitationAngle": self.params.excitationRadFA / np.pi * 180.0,
             "excitationPhase": self.params.excitationRfPhase,
-            "gradientExcitation": self._set_grad_for_emc(self.block_excitation.grad_slice.amplitude[-5]),
+            "gradientExcitation": self._set_grad_for_emc(self.block_excitation.grad_slice.amplitude[-2]),
             "durationExcitation": self.params.excitationDuration,
             "gradientExcitationRephase": self._set_grad_for_emc(self.block_excitation.grad_slice.amplitude[-2]),
             "durationExcitationRephase": np.sum(np.diff(self.block_excitation.grad_slice.t_array_s[-4:])) * 1e6,


### PR DESCRIPTION
When I tried to run the code from __main__.py with the default settings then I got two errors. One was because the `system `parameter were not set for `RF.make_sinc_pulse()`. The other was due to `self.block_excitation.grad_slice.amplitude` being of length 4 and hence the access [-5] failed. I arbitrarily set it to [-2]. Not sure what it should be. 